### PR TITLE
Add laserscan support to quanergy ROS driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
+  angles
   roscpp
   sensor_msgs
   pcl_ros
@@ -13,7 +14,12 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(QuanergyClient REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common io)
-find_package(FLANN REQUIRED)
+find_package(FLANN QUIET)
+
+if (NOT ${FLANN_FOUND})
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(flann REQUIRED)
+endif()
 
 # Workaround required due to a bug in VTK6 for Ubuntu 16.04
 # See https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
-  angles
   roscpp
   sensor_msgs
   pcl_ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(QuanergyClient REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common io)
+find_package(FLANN REQUIRED)
 
 # Workaround required due to a bug in VTK6 for Ubuntu 16.04
 # See https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234
@@ -37,6 +38,7 @@ include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
+  ${FLANN_INCLUDE_DIR}
 )
 
 link_directories(${PCL_LIBRARY_DIRS})
@@ -56,6 +58,7 @@ add_executable(client_node
  target_link_libraries(client_node
    ${catkin_LIBRARIES}
    ${PCL_LIBRARIES}
+   ${FLANN_LIBRARY}
    quanergy_client
  )
 

--- a/include/quanergy_client_ros/scan_publisher.h
+++ b/include/quanergy_client_ros/scan_publisher.h
@@ -1,0 +1,98 @@
+/****************************************************************
+ **                                                            **
+ **  Copyright(C) 2020 Quanergy Systems. All Rights Reserved.  **
+ **  Contact: http://www.quanergy.com                          **
+ **                                                            **
+ ****************************************************************/
+
+#ifndef QUANERGY_CLIENT_ROS_LASERSCAN_PUBLISHER_H
+#define QUANERGY_CLIENT_ROS_LASERSCAN_PUBLISHER_H
+
+#include <mutex>
+
+#include <quanergy/common/point_hvdir.h>
+#include <pcl/point_cloud.h>
+
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+
+/** \brief SimplePublisher publishes point clouds of type PointT */
+class ScanPublisher
+{
+public:
+  using Cloud = pcl::PointCloud<quanergy::PointHVDIR>;
+  using CloudConstPtr = typename Cloud::ConstPtr;
+
+  ScanPublisher(ros::NodeHandle& nh, std::string topic, std::string frame_id, bool use_ros_time = false)
+    : use_ros_time_(use_ros_time)
+  {
+    topic = nh.resolveName(topic);
+    publisher_ = nh.advertise<sensor_msgs::LaserScan>(topic, 10);
+    scan_.header.frame_id = frame_id;
+  }
+
+  void slot(const CloudConstPtr& cloud)
+  {
+    if(!ros::ok() || !cloud || cloud->empty()) return;
+
+    scan_.angle_min = cloud->front().h;
+    scan_.angle_max = cloud->back().h;
+
+    scan_.ranges.resize(cloud->size());
+    scan_.intensities.resize(cloud->size());
+
+    // scan.time_increment = ?
+    scan_.range_min = std::numeric_limits<float>::max();
+    scan_.range_max = std::numeric_limits<float>::lowest();  // Should have a fixed value
+
+    scan_.angle_increment = 0.0;
+
+    if (cloud->size() > 1)
+    {
+      scan_.angle_increment = (scan_.angle_max - scan_.angle_min) / static_cast<float>(cloud->size() - 1);
+    }
+
+    for (const auto& point : *cloud)
+    {
+      scan_.range_min = std::min(point.d, scan_.range_min);
+      scan_.range_max = std::max(point.d, scan_.range_max);
+    }
+
+    if (use_ros_time_)
+    {
+      scan_.header.stamp = ros::Time::now();
+    }
+
+    // don't block if publisher isn't available
+    std::unique_lock<std::timed_mutex> lock(publisher_mutex_, std::chrono::milliseconds(10));
+    if (lock)
+    {
+      publisher_.publish(scan_);
+    }
+  }
+
+  /** \brief run the publisher; blocks until done */
+  void run(double frequency = 50.)
+  {
+    ros::Rate r(frequency);
+    while (ros::ok())
+    {
+      ros::spinOnce();
+      r.sleep();
+    }
+  }
+
+  void stop()
+  {
+    ros::shutdown();
+  }
+
+private:
+  std::timed_mutex publisher_mutex_;
+  bool use_ros_time_;
+  sensor_msgs::LaserScan scan_;
+  ros::Publisher publisher_;
+};
+
+
+#endif

--- a/include/quanergy_client_ros/scan_publisher.h
+++ b/include/quanergy_client_ros/scan_publisher.h
@@ -50,15 +50,15 @@ public:
     ros::NodeHandle& nh,
     const std::string& topic,
     double frame_rate,
-    float min_range,
-    float max_range,
+    float range_min,
+    float range_max,
     bool use_ros_time = true)
     : use_ros_time_(use_ros_time)
   {
     publisher_ = nh.advertise<sensor_msgs::LaserScan>(topic, 10);
 
-    scan_.range_min = min_range;
-    scan_.range_max = max_range;
+    scan_.range_min = range_min;
+    scan_.range_max = range_max;
     scan_.scan_time = 1.0f / static_cast<float>(frame_rate);
   }
 
@@ -79,12 +79,12 @@ public:
     {
       const auto& point = cloud_deref[i];
 
+      // Some scans have points near pi at the start (possible left over from a previous scan?)
       if (i > 0 && cloud_deref[i - 1].h > point.h)
       {
-        scan_.ranges.back() = point.d;
-        scan_.intensities.back() = point.intensity;
+        scan_.ranges.clear();
+        scan_.intensities.clear();
         start_i = i;
-        continue;
       }
 
       scan_.ranges.push_back(point.d);

--- a/include/quanergy_client_ros/scan_publisher.h
+++ b/include/quanergy_client_ros/scan_publisher.h
@@ -27,9 +27,9 @@ public:
   ScanPublisher(
     ros::NodeHandle& nh,
     const std::string& topic,
+    double frame_rate,
     float min_range,
     float max_range,
-    double frame_rate,
     bool use_ros_time = true)
     : use_ros_time_(use_ros_time)
   {

--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,6 @@
   <build_depend>sensor_msgs</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>libflann-dev</build_depend>
   <run_depend>pcl_ros</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
 
   <build_depend>libflann-dev</build_depend>
 
-  <depend>angles</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>pcl_ros</depend>

--- a/package.xml
+++ b/package.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>quanergy_client_ros</name>
   <version>3.1.1</version>
   <description>The quanergy_client_ros package provides a ROS driver for Quanergy sensors</description>
   <maintainer email="ross.taylor@quanergy.com">Ross Taylor</maintainer>
   <license>Copyright 2014- Quanergy Systems Inc.</license>
+
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <run_depend>roscpp</run_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <build_depend>pcl_ros</build_depend>
+
   <build_depend>libflann-dev</build_depend>
-  <run_depend>pcl_ros</run_depend>
+
+  <depend>angles</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>pcl_ros</depend>
 </package>

--- a/src/client_node.cpp
+++ b/src/client_node.cpp
@@ -7,6 +7,7 @@
 
 // publisher module
 #include <quanergy_client_ros/simple_publisher.h>
+#include <quanergy_client_ros/scan_publisher.h>
 
 #include <quanergy/client/version.h>
 
@@ -198,9 +199,11 @@ int main(int argc, char** argv)
   // we may need multiple for separate_return_topics
   std::list<quanergy::pipeline::SensorPipeline> pipelines;
 
-  // create list (because it is noncopyable) of ROS publishers to consume point clouds and publish them
+  // create list (because it is noncopyable) of ROS cloud_publishers to consume point clouds and publish them
+  // also create publishers for laser scans
   // we may need multiple for separate_return_topics
-  std::list<SimplePublisher<quanergy::PointXYZIR>> publishers;
+  std::list<SimplePublisher<quanergy::PointXYZIR>> cloud_publishers;
+  std::list<ScanPublisher> scan_publishers;
 
   // create vector of threads for publisher(s)
   // we may need multiple for separate_return_topics
@@ -236,8 +239,10 @@ int main(int argc, char** argv)
     auto& pipeline = pipelines.back();
 
     // create publisher and get reference to it
-    publishers.emplace_back(nh, topic, ros_node_settings.use_ros_time);
-    auto& publisher = publishers.back();
+    cloud_publishers.emplace_back(nh, topic, ros_node_settings.use_ros_time);
+    scan_publishers.emplace_back(nh, topic + "_scan", pipeline_settings.frame, ros_node_settings.use_ros_time);
+    auto& cloud_publisher = cloud_publishers.back();
+    auto& scan_publisher = scan_publishers.back();
 
     if (ros_node_settings.separate_return_topics)
     {
@@ -265,27 +270,45 @@ int main(int argc, char** argv)
     }
 
     // connect the pipeline to the publisher
-    connections.push_back(pipeline.connect(
-        [&publisher](const boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>& pc){ publisher.slot(pc); }
+    connections.push_back(pipeline.connect_cloud(
+        [&cloud_publisher](const boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>& pc){ cloud_publisher.slot(pc); }
+    ));
+
+    connections.push_back(pipeline.connect_scan(
+        [&scan_publisher](const boost::shared_ptr<pcl::PointCloud<quanergy::PointHVDIR>>& pc){ scan_publisher.slot(pc); }
     ));
 
     // create publisher thread
     publisher_threads.emplace_back(
-      [&publisher, &client_mutex, &client, &publishers_count, &publisher_cv]
+      [&cloud_publisher, &client_mutex, &client, &publishers_count, &publisher_cv]
       {
         std::unique_lock<std::mutex> lock(client_mutex);
         ++publishers_count;
         lock.unlock();
         publisher_cv.notify_one();
 
-        publisher.run();
+        cloud_publisher.run();
+        lock.lock();
+        client.stop();
+      }
+    );
+
+    publisher_threads.emplace_back(
+      [&scan_publisher, &client_mutex, &client, &publishers_count, &publisher_cv]
+      {
+        std::unique_lock<std::mutex> lock(client_mutex);
+        ++publishers_count;
+        lock.unlock();
+        publisher_cv.notify_one();
+
+        scan_publisher.run();
         lock.lock();
         client.stop();
       }
     );
   }
 
-  // this makes sure the publishers have started; without it, sometimes the client starts first (due to OS scheduling)
+  // this makes sure the cloud_publishers have started; without it, sometimes the client starts first (due to OS scheduling)
   // and then we get a bunch of warning messages related to data coming in without being consumed
   {
     std::unique_lock<std::mutex> lock(client_mutex);

--- a/src/client_node.cpp
+++ b/src/client_node.cpp
@@ -307,7 +307,7 @@ int main(int argc, char** argv)
         lock.unlock();
         publisher_cv.notify_one();
 
-        scan_publisher.run();
+        ros::spin();
         lock.lock();
         client.stop();
       }

--- a/src/client_node.cpp
+++ b/src/client_node.cpp
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
     );
   }
 
-  // this makes sure the cloud_publishers have started; without it, sometimes the client starts first (due to OS scheduling)
+  // this makes sure the publishers have started; without it, sometimes the client starts first (due to OS scheduling)
   // and then we get a bunch of warning messages related to data coming in without being consumed
   {
     std::unique_lock<std::mutex> lock(client_mutex);

--- a/src/client_node.cpp
+++ b/src/client_node.cpp
@@ -239,8 +239,14 @@ int main(int argc, char** argv)
     auto& pipeline = pipelines.back();
 
     // create publisher and get reference to it
-    cloud_publishers.emplace_back(nh, topic, ros_node_settings.use_ros_time);
-    scan_publishers.emplace_back(nh, topic + "_scan", pipeline_settings.frame, ros_node_settings.use_ros_time);
+    cloud_publishers.emplace_back(nh, topic + "_cloud", ros_node_settings.use_ros_time);
+    scan_publishers.emplace_back(
+      nh,
+      topic,
+      pipeline_settings.frame_rate,
+      pipeline_settings.min_distance,
+      pipeline_settings.max_distance,
+      ros_node_settings.use_ros_time);
     auto& cloud_publisher = cloud_publishers.back();
     auto& scan_publisher = scan_publishers.back();
 


### PR DESCRIPTION
Goes with https://github.com/locusrobotics/quanergy_client/pull/1

This PR adds support for publishing `sensor_msgs/LaserScan` messages from the quanergy M1 lidar for Jeff's mapper bot. It builds on my focal machine and on a robot.

This isn't the cleanest code, but then I don't want this project eating a lot of time.